### PR TITLE
add missing .travis.yml to fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "0.10"
+  - "iojs"


### PR DESCRIPTION
Travis is broken since there is no .travis.yml file. This will fix things so tests run again. However, tests will still fail until https://github.com/ghostsnstuff/kickstarter-crawler/pull/25 is merged.